### PR TITLE
make self_and_descendants, self_and_ancestors always return scopes

### DIFF
--- a/lib/simple_nested_set/class_methods.rb
+++ b/lib/simple_nested_set/class_methods.rb
@@ -37,12 +37,20 @@ module SimpleNestedSet
       where(:parent_id => parent_id).order(:lft)
     end
 
-    def with_ancestors(lft, rgt)
-      where(arel_table[:lft].lt(lft).and(arel_table[:rgt].gt(rgt))).order(:lft)
+    def with_ancestors(lft, rgt, opts = {})
+      if opts.fetch(:include_self, false)
+        where(arel_table[:lft].lteq(lft).and(arel_table[:rgt].gteq(rgt))).order(:lft)
+      else
+        where(arel_table[:lft].lt(lft).and(arel_table[:rgt].gt(rgt))).order(:lft)
+      end
     end
 
-    def with_descendants(lft, rgt)
-      where(arel_table[:lft].gt(lft).and(arel_table[:rgt].lt(rgt))).order(:lft)
+    def with_descendants(lft, rgt, opts = {})
+      if opts.fetch(:include_self, false)
+        where(arel_table[:lft].gteq(lft).and(arel_table[:rgt].lteq(rgt))).order(:lft)
+      else
+        where(arel_table[:lft].gt(lft).and(arel_table[:rgt].lt(rgt))).order(:lft)
+      end
     end
 
     def with_left_sibling(lft)

--- a/lib/simple_nested_set/instance_methods.rb
+++ b/lib/simple_nested_set/instance_methods.rb
@@ -63,13 +63,13 @@ module SimpleNestedSet
     end
 
     # Returns an array of all parents
-    def ancestors
-      nested_set.with_ancestors(lft, rgt)
+    def ancestors(opts = {})
+      nested_set.with_ancestors(lft, rgt, opts)
     end
 
     # Returns the array of all parents and self
     def self_and_ancestors
-      ancestors + [self]
+      ancestors(:include_self => true)
     end
 
     # Returns true if this is a descendent of the given node
@@ -83,13 +83,13 @@ module SimpleNestedSet
     end
 
     # Returns a set of all of its children and nested children.
-    def descendants
-      rgt - lft == 1 ? []  : nested_set.with_descendants(lft, rgt)
+    def descendants(opts = {})
+      nested_set.with_descendants(lft, rgt, opts)
     end
 
     # Returns a set of itself and all of its nested children.
     def self_and_descendants
-      [self] + descendants
+      descendants(:include_self => true)
     end
 
     # Returns the number of descendants

--- a/test/instance_methods_test.rb
+++ b/test/instance_methods_test.rb
@@ -118,6 +118,12 @@ class NestedSetTest < Test::Unit::TestCase
     assert_equal [child_2_1], child_2_1.self_and_siblings
   end
 
+  test "node.self_and_children returns node and the node's children" do
+    assert_equal [root, child_1, child_2], root.self_and_children
+    assert_equal [child_1], child_1.self_and_children
+    assert_equal [child_2, child_2_1], child_2.self_and_children
+  end
+
   test "node.leaves returns all of this node's descendants that are leaves" do
     assert_equal [child_1, child_2_1], root.leaves
     assert_equal [], child_1.leaves
@@ -129,8 +135,16 @@ class NestedSetTest < Test::Unit::TestCase
     assert_equal [child_1, child_2, child_2_1], root.descendants
   end
 
+  test "node.descendants returns empty list for a leaf node" do
+    assert_equal [], child_2_1.descendants
+  end
+
   test "node.self_and_descendants returns the node and the node's descendants" do
     assert_equal [root, child_1, child_2, child_2_1], root.self_and_descendants
+  end
+
+  test "node.self_and_descendants returns only self for leaf nodes" do
+    assert_equal [child_1], child_1.self_and_descendants
   end
 
   test "node.descendants_count returns the node's number of children" do

--- a/test/instance_methods_test.rb
+++ b/test/instance_methods_test.rb
@@ -103,6 +103,11 @@ class NestedSetTest < Test::Unit::TestCase
     assert_equal [root, child_2, child_2_1], child_2_1.self_and_ancestors
   end
 
+  test "node.self_and_ancestors should return a relation" do
+    assert child_2_1.self_and_ancestors.is_a?(ActiveRecord::Relation)
+    assert root.self_and_ancestors.is_a?(ActiveRecord::Relation)
+  end
+
   test "node.siblings returns the node's siblings" do
     assert_equal [], root.siblings
     assert_equal [child_2], child_1.siblings
@@ -145,6 +150,11 @@ class NestedSetTest < Test::Unit::TestCase
 
   test "node.self_and_descendants returns only self for leaf nodes" do
     assert_equal [child_1], child_1.self_and_descendants
+  end
+
+  test "node.self_and_descendants should return a relation" do
+    assert root.self_and_descendants.is_a?(ActiveRecord::Relation)
+    assert child_1.self_and_descendants.is_a?(ActiveRecord::Relation)
   end
 
   test "node.descendants_count returns the node's number of children" do


### PR DESCRIPTION
- I'm not sure if the `include_self` parameter is a good enough API
- I have removed the special case check for leaf nodes in #descendants, calling #descendants on leaf nodes will now hit the DB where before it wouldn't
