### PR TITLE
Allow nodes to change parents by using node.parent= method

### DIFF
--- a/lib/simple_nested_set/act_macro.rb
+++ b/lib/simple_nested_set/act_macro.rb
@@ -16,7 +16,7 @@ module SimpleNestedSet
       after_save     lambda { |r| r.nested_set.save! }
 
       belongs_to :parent, :class_name => self.name
-      has_many :children, :foreign_key => :parent_id, :class_name => self.name
+      has_many :children, :foreign_key => :parent_id, :class_name => self.name, :order => :lft
 
       default_scope :order => :lft
 

--- a/lib/simple_nested_set/move/by_attributes.rb
+++ b/lib/simple_nested_set/move/by_attributes.rb
@@ -36,7 +36,7 @@ module SimpleNestedSet
         end
 
         def move_by_parent_id?
-          attributes.key?(:parent_id) && parent_id != node.parent_id
+          node.parent_id_changed?
         end
 
         def move_by_left_id
@@ -52,7 +52,7 @@ module SimpleNestedSet
         end
 
         def parent_id
-          attributes[:parent_id].blank? ? nil : attributes[:parent_id].to_i
+          attributes[:parent_id] == 0 ? nil : attributes[:parent_id]
         end
 
         def left_id

--- a/lib/simple_nested_set/move/to_target.rb
+++ b/lib/simple_nested_set/move/to_target.rb
@@ -71,7 +71,7 @@ module SimpleNestedSet
             when :child ; target.rgt
             when :left  ; target.lft
             when :right ; target.rgt + 1
-            when :root  ; roots.empty? ? 1 : roots.last.rgt + 1
+            when :root  ; roots.empty? ? 1 : roots.where('id <> ?', node.id).last.rgt + 1
           end
           bound > node.rgt ? bound - 1 : bound
         end

--- a/lib/simple_nested_set/nested_set.rb
+++ b/lib/simple_nested_set/nested_set.rb
@@ -101,7 +101,6 @@ module SimpleNestedSet
     def populate_associations(nodes)
       node.children.target = nodes.select do |child|
         next unless child.parent_id == node.id
-        nodes.delete(child)
         child.nested_set.populate_associations(nodes)
         child.parent = node
       end

--- a/test/associations_test.rb
+++ b/test/associations_test.rb
@@ -56,4 +56,17 @@ class NestedSetTest < Test::Unit::TestCase
     assert_equal ['foo', 1, 2, 'foo'], [foo.slug, foo.lft, foo.rgt, foo.path]
     assert_equal ['bar', 3, 4, 'bar'], [bar.slug, bar.lft, bar.rgt, bar.path]
   end
+
+  test "load_tree on a association doesn't destroy collection" do
+    owner = NodeOwner.create!
+    foo_node = owner.nodes.create!(:slug => 'foo', :scope_id => 3)
+    owner.nodes.create!(:slug => 'bar', :scope_id => 3, :parent => foo_node)
+    owner.reload
+    owner.nodes.reset
+    owner.nodes.roots.each { |root| root.load_tree }
+
+    assert_equal [owner.id, owner.id], owner.nodes.map(&:node_owner_id)
+  end
+
+
 end

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -26,10 +26,10 @@ class NestedSetTest < Test::Unit::TestCase
   # CALLBACKS
 
   test "before_move get's called after a new node was created and before it is now moved to its new parent" do
-    parent_id = false
-    Node.send(:before_move) { |node| parent_id = node.parent_id }
+    lft = nil
+    Node.send(:before_move) { |node| lft = node.lft }
     Node.create!(:scope_id => 1, :parent_id => child_2.id)
-    assert_nil parent_id
+    assert child_2.rgt < lft
   end
 
   test "before_move get's called before an existing node is moved" do

--- a/test/instance_methods_test.rb
+++ b/test/instance_methods_test.rb
@@ -87,6 +87,9 @@ class NestedSetTest < Test::Unit::TestCase
     assert_equal root, child_1.parent
     assert_equal root, child_2.parent
     assert_equal child_2, child_2_1.parent
+
+    @child_1_1 = Node.new(:slug => 'child_1_1', :scope_id => 1, :parent => child_1)
+    assert_equal child_1, @child_1_1.parent
   end
 
   test "node.ancestors returns the node's ancestors" do

--- a/test/movements_test.rb
+++ b/test/movements_test.rb
@@ -190,4 +190,13 @@ class NestedSetTest < Test::Unit::TestCase
       Node.create!(:slug => 'nil_value', :parent => nil)
     end
   end
+
+  test "node.parent = parent is equal to node.update_attributes(:parent_id => parent)" do
+    child_1_1 = Node.new(:slug => 'child_1_1', :scope_id => 1, :parent => child_1)
+    child_1_2 = Node.new(:slug => 'child_1_2', :scope_id => 1) { |node| node.parent = child_1 }
+
+    [child_1_1, child_1_2].each { |node| node.save; node.reload }
+    child_1.reload
+    assert_equal [child_1_1, child_1_2], child_1.descendants
+  end
 end


### PR DESCRIPTION
Hi! 

I had problems setting parent relation, and then reading it back.

The gist https://gist.github.com/814262 shows the code.

These patches allow one to set parent relation with #parent=(new_parent). New value is immediately available via #parent method, so it can be used in validations. 

Tests are supplied as separate commit. 
